### PR TITLE
feat: [CO-772] Add support for custom login/logout URL for domains

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.admin.default.template
+++ b/conf/nginx/templates/nginx.conf.web.admin.default.template
@@ -6,8 +6,7 @@ server
     ${core.ipboth.enabled}listen                  [::]:${web.admin.port} default_server ssl;
     ${core.ipv4only.enabled}listen                ${web.admin.port} default_server ssl;
     ${core.ipv6only.enabled}listen                [::]:${web.admin.port} default_server ssl;
-    ${web.add.headers.default}
-    client_max_body_size    0;
+
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};
@@ -19,6 +18,12 @@ server
     proxy_ssl_protocols           ${web.ssl.protocols};
     proxy_ssl_ciphers             ${web.ssl.ciphers};
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
+
+    # no maximum limit imposed on the size of the request body
+    client_max_body_size    0;
+
+    # response headers
+    ${web.add.headers.default}
 
     location /
     {

--- a/conf/nginx/templates/nginx.conf.web.admin.template
+++ b/conf/nginx/templates/nginx.conf.web.admin.template
@@ -4,11 +4,11 @@
 server
 {
     server_name             ${vhn};
+
     ${core.ipboth.enabled}listen                    ${vip}${web.admin.port} ssl;
     ${core.ipv4only.enabled}listen                  ${vip}${web.admin.port} ssl;
     ${core.ipv6only.enabled}listen                  ${vip}${web.admin.port} ssl;
-    ${web.add.headers.vhost}
-    client_max_body_size    0;
+
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};
@@ -21,6 +21,11 @@ server
     proxy_ssl_ciphers             ${web.ssl.ciphers};
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
 
+    # no maximum limit imposed on the size of the request body
+    client_max_body_size    0;
+
+    # response headers
+    ${web.add.headers.vhost}
 
     location /
     {

--- a/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
+++ b/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
@@ -6,8 +6,7 @@ server
     ${core.ipboth.enabled}listen                  [::]:${web.carbonio.admin.port} default_server ssl;
     ${core.ipv4only.enabled}listen                ${web.carbonio.admin.port} default_server ssl;
     ${core.ipv6only.enabled}listen                [::]:${web.carbonio.admin.port} default_server ssl;
-    ${web.add.headers.default}
-    client_max_body_size    0;
+
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};
@@ -20,12 +19,19 @@ server
     proxy_ssl_ciphers             ${web.ssl.ciphers};
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
 
+    # no maximum limit imposed on the size of the request body
+    client_max_body_size    0;
+
+    # nginx compression
     ${proxy.http.compression}
+
+    # response headers
+    ${web.add.headers.default}
 
     location /
     {
         if ($http_cookie !~ "ZM_ADMIN_AUTH_TOKEN=") {
-            return 307 "/static/login/";
+            return 307 ${web.carbonio.admin.login.url.default};
         }
         return 307 "/carbonioAdmin";
     }
@@ -93,7 +99,7 @@ server
         add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
         add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
         add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-        return 307 "/static/login/";
+        ${web.carbonio.admin.logout.redirect.default};
     }
 
     location ^~ /zx/

--- a/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
+++ b/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
@@ -4,11 +4,10 @@
 server
 {
     server_name             ${vhn};
+
     ${core.ipboth.enabled}listen                    ${vip}${web.carbonio.admin.port} ssl;
     ${core.ipv4only.enabled}listen                  ${vip}${web.carbonio.admin.port} ssl;
     ${core.ipv6only.enabled}listen                  ${vip}${web.carbonio.admin.port} ssl;
-    ${web.add.headers.vhost}
-    client_max_body_size    0;
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};
@@ -21,12 +20,19 @@ server
     proxy_ssl_ciphers             ${web.ssl.ciphers};
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
 
+    # no maximum limit imposed on the size of the request body
+    client_max_body_size    0;
+
+    # nginx compression
     ${proxy.http.compression}
+
+    # response headers
+    ${web.add.headers.vhost}
 
     location /
     {
         if ($http_cookie !~ "ZM_ADMIN_AUTH_TOKEN=") {
-            return 307 "/static/login/";
+            return 307 ${web.carbonio.admin.login.url.vhost};
         }
         return 307 "/carbonioAdmin";
     }
@@ -94,7 +100,7 @@ server
         add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
         add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
         add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-        return 307 "/static/login/";
+        ${web.carbonio.admin.logout.redirect.vhost};
     }
 
     location ^~ /zx/

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -70,11 +70,13 @@ server
     }
 
     # if to loginOp is logout, all the requests should be routed to login server so that updated assets can be loaded
+    # Marked for removal: will be removed in 23.10.0 and logout will be handled at ~/logout
     if ($arg_loginOp = "logout") {
         set $login_upstream    ${web.upstream.login.target};
     }
 
     # Same as above for relogin loginOp
+    # Marked for removal: will be removed in 23.10.0
     if ($arg_loginOp = "relogin") {
         set $login_upstream    ${web.upstream.login.target};
     }
@@ -83,6 +85,18 @@ server
     # server - which could be an old one and not yet upgraded
     if ($arg_client = "mobile") {
         set $login_upstream    https://zimbra_ssl_webclient;
+    }
+
+    location ~/logout
+    {
+        add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "JSESSIONID=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "AUTH_TOKEN_TYPE=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        ${web.carbonio.webui.logout.redirect.default};
     }
 
     location ~/static/(.*)
@@ -205,7 +219,7 @@ server
     {
         # End user session and redirect them to logout URL.
         # Defaults to /static/login/
-        # NOTE: Keep this on top of location /
+        # Marked for removal: will be removed in 23.10.0 and logout will be handled at ~/logout
         if ($query_string ~ loginOp=logout) {
             add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -34,14 +34,13 @@ map $http_cookie $auth_token_cookie {
 
 server
 {
+    server_name             ${web.server_name.default}; # add aliases and perhaps public
+
     ${core.ipboth.enabled}listen                  ${web.https.port} default_server ssl http2;
     ${core.ipboth.enabled}listen                  [::]:${web.https.port} default_server ssl http2;
     ${core.ipv4only.enabled}listen                ${web.https.port} default_server ssl http2;
     ${core.ipv6only.enabled}listen                [::]:${web.https.port} default_server ssl http2;
 
-    ${web.add.headers.default}
-    server_name             ${web.server_name.default}; # add aliases and perhaps public
-    client_max_body_size    0;
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};
@@ -56,7 +55,14 @@ server
     proxy_ssl_ciphers             ${web.ssl.ciphers};
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
 
+    # no maximum limit imposed on the size of the request body
+    client_max_body_size    0;
+
+    # nginx compression
     ${proxy.http.compression}
+
+    # response headers
+    ${web.add.headers.default}
 
     set $login_upstream     ${web.upstream.login.target};
     if ($http_cookie ~ "ZM_AUTH_TOKEN=") {
@@ -78,7 +84,6 @@ server
     if ($arg_client = "mobile") {
         set $login_upstream    https://zimbra_ssl_webclient;
     }
-
 
     location ~/static/(.*)
     {
@@ -186,7 +191,7 @@ server
     location ~ ^/carbonio(/|$)
     {
         if ($auth_token_cookie = 0) {
-            return 307 "/static/login/";
+            return 307 ${web.carbonio.webui.login.url.default};
         }
 
         try_files index.html /carbonio/;
@@ -198,9 +203,24 @@ server
 
     location = /
     {
+        # End user session and redirect them to logout URL.
+        # Defaults to /static/login/
+        # NOTE: Keep this on top of location /
+        if ($query_string ~ loginOp=logout) {
+            add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "JSESSIONID=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "AUTH_TOKEN_TYPE=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            ${web.carbonio.webui.logout.redirect.default};
+        }
 
+        # Redirect user to login URL.
+        # Defaults to /static/login/
         if ($auth_token_cookie = 0) {
-            return 307 "/static/login/";
+            return 307 ${web.carbonio.webui.login.url.default};
         }
 
         # Begin stray redirect hack
@@ -251,17 +271,6 @@ server
 
         # Fudge inter-mailbox redirects (kludge)
         proxy_redirect http://$relhost/ https://$http_host/;
-
-        if ($query_string ~ loginOp=logout) {
-            add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "JSESSIONID=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "AUTH_TOKEN_TYPE=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            return 307 "/static/login/";
-        }
 
         return 307 "/carbonio/";
     }

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -10,11 +10,11 @@ map $http_cookie $auth_token_cookie {
 server
 {
     server_name             ${vhn};
+
     ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ssl http2;
     ${core.ipv4only.enabled}listen                  ${vip}${web.https.port} ssl http2;
     ${core.ipv6only.enabled}listen                  ${vip}${web.https.port} ssl http2;
-    ${web.add.headers.vhost}
-    client_max_body_size    0;
+
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};
@@ -28,19 +28,25 @@ server
     proxy_ssl_ciphers             ${web.ssl.ciphers};
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
 
+    # no maximum limit imposed on the size of the request body
+    client_max_body_size    0;
+
+    # nginx compression
     ${proxy.http.compression}
+
+    # response headers
+    ${web.add.headers.vhost}
 
     set $login_upstream     ${web.upstream.login.target};
     if ($http_cookie ~ "ZM_AUTH_TOKEN=") {
         set $login_upstream    ${web.upstream.webclient.target};
     }
 
-
     location = ${web.login.upstream.url}/
     {
-        if ($http_cookie !~ "ZM_AUTH_TOKEN=") {
-            return 307 "/static/login/";
-        }
+      if ($auth_token_cookie = 0) {
+        return 307 ${web.carbonio.webui.login.url.vhost};
+      }
     }
 
     location ~/static/(.*)
@@ -149,7 +155,7 @@ server
     location ~ ^/carbonio(/|$)
     {
         if ($auth_token_cookie = 0) {
-            return 307 "/static/login/";
+            return 307 ${web.carbonio.webui.login.url.vhost};
         }
 
         try_files index.html /carbonio/;
@@ -161,9 +167,24 @@ server
 
     location = /
     {
+        # End user session and redirect them to logout URL.
+        # Defaults to /static/login/
+        # NOTE: Keep this on top of location /
+        if ($query_string ~ loginOp=logout) {
+            add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "JSESSIONID=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "AUTH_TOKEN_TYPE=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+            ${web.carbonio.webui.logout.redirect.vhost};
+        }
 
+        # Redirect user to login URL.
+        # Defaults to /static/login/
         if ($auth_token_cookie = 0) {
-            return 307 "/static/login/";
+          return 307 ${web.carbonio.webui.login.url.vhost};
         }
 
         # Begin stray redirect hack
@@ -214,17 +235,6 @@ server
 
         # Fudge inter-mailbox redirects (kludge)
         proxy_redirect http://$relhost/ https://$http_host/;
-
-        if ($query_string ~ loginOp=logout) {
-            add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "JSESSIONID=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "AUTH_TOKEN_TYPE=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
-            return 307 "/static/login/";
-        }
 
         return 307 "/carbonio/";
     }

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -49,6 +49,18 @@ server
       }
     }
 
+    location ~/logout
+    {
+        add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "JSESSIONID=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "AUTH_TOKEN_TYPE=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        ${web.carbonio.webui.logout.redirect.vhost};
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.vhost}
@@ -169,7 +181,7 @@ server
     {
         # End user session and redirect them to logout URL.
         # Defaults to /static/login/
-        # NOTE: Keep this on top of location /
+        # Marked for removal: will be removed in 23.10.0 and logout will be handled at ~/logout
         if ($query_string ~ loginOp=logout) {
             add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";


### PR DESCRIPTION
**What has changed:**
- minor cleanup targetting unification of web templates.
- new variables to support redirection of web login and logout for both default and virtualhost templates all defaulting to /static/login/ path
    - for handling login `web.carbonio.[webui|admin].login.url.[default|vhost]`
    - for handling logout `web.carbonio.[webui|admin].logout.redirect.[default|vhost]`

**Related PRs:**
- https://github.com/zextras/carbonio-mailbox/pull/301

**Note:** the redirection of logout is handled by othe carbonio components like UI and Auth.

**DO NOT SQUASH**