### PR TITLE
feat: [CO-813] Add logout endpoint to handle user logout

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -70,11 +70,13 @@ server
     }
 
     # if to loginOp is logout, all the requests should be routed to login server so that updated assets can be loaded
+    # Marked for removal: will be removed in 23.10.0 and logout will be handled at ~/logout
     if ($arg_loginOp = "logout") {
         set $login_upstream    ${web.upstream.login.target};
     }
 
     # Same as above for relogin loginOp
+    # Marked for removal: will be removed in 23.10.0
     if ($arg_loginOp = "relogin") {
         set $login_upstream    ${web.upstream.login.target};
     }
@@ -217,7 +219,7 @@ server
     {
         # End user session and redirect them to logout URL.
         # Defaults to /static/login/
-        # NOTE: Keep this on top of location /
+        # Marked for removal: will be removed in 23.10.0 and logout will be handled at ~/logout
         if ($query_string ~ loginOp=logout) {
             add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -85,6 +85,18 @@ server
         set $login_upstream    https://zimbra_ssl_webclient;
     }
 
+    location ~/logout
+    {
+        add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "JSESSIONID=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "AUTH_TOKEN_TYPE=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        ${web.carbonio.webui.logout.redirect.default};
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.default}

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -181,7 +181,7 @@ server
     {
         # End user session and redirect them to logout URL.
         # Defaults to /static/login/
-        # NOTE: Keep this on top of location /
+        # Marked for removal: will be removed in 23.10.0 and logout will be handled at ~/logout
         if ($query_string ~ loginOp=logout) {
             add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
             add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -49,6 +49,18 @@ server
       }
     }
 
+    location ~/logout
+    {
+        add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "ZX_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "JSESSIONID=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "AUTH_TOKEN_TYPE=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "T=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "Y=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        add_header Set-Cookie "ADMIN_AUTH_KEY=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";
+        ${web.carbonio.webui.logout.redirect.vhost};
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.vhost}


### PR DESCRIPTION
**What has changed:**
- In order to uniform the logout handling across Admin UI and Web UI, separate logout path was added in the Web proxy templates targeting Default and VirtualHost proxy config.

- The old query parameter based (loginOp=logout) endpoint will be removed in next version of Carbonio, Deprecation note has been added to imply the same in the template.