### PR TITLE
fix: [CO-855] Carbonio shows Jetty favicon instead of Carbonio one

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
+++ b/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
@@ -28,6 +28,11 @@ server
     # response headers
     ${web.add.headers.default}
 
+    location = /favicon.ico
+    {
+      return 404;
+    }
+
     location /
     {
         if ($http_cookie !~ "ZM_ADMIN_AUTH_TOKEN=") {

--- a/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
+++ b/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
@@ -29,6 +29,11 @@ server
     # response headers
     ${web.add.headers.vhost}
 
+    location = /favicon.ico
+    {
+      return 404;
+    }
+
     location /
     {
         if ($http_cookie !~ "ZM_ADMIN_AUTH_TOKEN=") {

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -87,6 +87,11 @@ server
         set $login_upstream    https://zimbra_ssl_webclient;
     }
 
+    location = /favicon.ico
+    {
+      return 404;
+    }
+
     location ~/logout
     {
         add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -49,6 +49,11 @@ server
       }
     }
 
+    location = /favicon.ico
+    {
+      return 404;
+    }
+
     location ~/logout
     {
         add_header Set-Cookie "ZM_AUTH_TOKEN=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0";


### PR DESCRIPTION
**What has changed:**

-  start mapping the /favicon.ico location to 404 error

ref: CO-855