### PR TITLE
feat: add nginx rule to fetch carbonio-files-public-folder-ui bundle

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -126,6 +126,19 @@ server
         alias /opt/zextras/web/iris/carbonio-chats-ui/current/meeting/;
     }
 
+    location /files/public/link/access/assets/
+    {
+        ${web.add.headers.default}
+        alias /opt/zextras/web/carbonio-files-public-folder-ui/assets/;
+    }
+
+    location /files/public/link/access/
+    {
+        ${web.add.headers.default}
+        try_files index.html /carbonio-files-public-folder-ui/;
+        alias /opt/zextras/web/carbonio-files-public-folder-ui/;
+    }
+
     location /services/files/
     {
         proxy_request_buffering off;

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -88,6 +88,19 @@ server
         alias /opt/zextras/web/iris/carbonio-chats-ui/current/meeting/;
     }
 
+    location /files/public/link/access/assets/
+    {
+        ${web.add.headers.default}
+        alias /opt/zextras/web/carbonio-files-public-folder-ui/assets/;
+    }
+
+    location /files/public/link/access/
+    {
+        ${web.add.headers.default}
+        try_files index.html /carbonio-files-public-folder-ui/;
+        alias /opt/zextras/web/carbonio-files-public-folder-ui/;
+    }
+
     location /services/files/
     {
         proxy_request_buffering off;


### PR DESCRIPTION
Added two rules to fetch the [carbonio-files-public-folder-ui](https://github.com/zextras/carbonio-files-public-folder-ui) bundle necessary to access a carbonio-files public folder without authentication.

The first rule is tied to the `/files/public/link/access/assets/` endpoint and it allows to download all the assets required by the bundle.

The second rule is tied to the `/files/public/link/access/` endpoint and it downloads the index.html of the bundle.

Ref: FILES-734