### PR TITLE
feat: add new location for meetings

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -246,6 +246,14 @@ server
         proxy_pass http://carbonio-auth/zx/auth/;
     }
 
+    location ~ ^/carbonio/focus-mode/meetings(/|$)
+    {
+        try_files index.html /carbonio/focus-mode/meetings/;
+        ${web.add.headers.default}
+        add_header Cache-Control "no-cache,must-revalidate,no-transform,max-age=604800";
+        alias /opt/zextras/web/iris/carbonio-shell-ui/current/;
+    }
+
     location ~ ^/carbonio(/|$)
     {
         if ($auth_token_cookie = 0) {

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -208,7 +208,15 @@ server
         proxy_pass http://carbonio-auth/zx/auth/;
     }
 
-    location ~ ^/carbonio(/|$)
+    location ~ ^/carbonio/focus-mode/meetings(/|$)
+    {
+        try_files index.html /carbonio/focus-mode/meetings/;
+        ${web.add.headers.default}
+        add_header Cache-Control "no-cache,must-revalidate,no-transform,max-age=604800";
+        alias /opt/zextras/web/iris/carbonio-shell-ui/current/;
+    }
+
+	  location ~ ^/carbonio(/|$)
     {
         if ($auth_token_cookie = 0) {
             return 307 ${web.carbonio.webui.login.url.vhost};

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -216,7 +216,7 @@ server
         alias /opt/zextras/web/iris/carbonio-shell-ui/current/;
     }
 
-	  location ~ ^/carbonio(/|$)
+    location ~ ^/carbonio(/|$)
     {
         if ($auth_token_cookie = 0) {
             return 307 ${web.carbonio.webui.login.url.vhost};


### PR DESCRIPTION
The purpose of this new location is to provide correct error pages for external users attempting to join a meeting via link

refs: WSC-1342