### PR TITLE
chore: remove .pid files references

### DIFF
--- a/conf/nginx/templates/nginx.conf.main.template
+++ b/conf/nginx/templates/nginx.conf.main.template
@@ -6,7 +6,6 @@
 worker_processes auto;
 # worker_processes ${main.workers};
 
-pid        ${main.pidfile};
 error_log  ${main.logfile} ${main.loglevel};
 
 


### PR DESCRIPTION
pidfile path is now managed at [built-time](https://github.com/zextras/carbonio-thirds/blob/b514f7c7f9b271fd4a426b035132f8f7d566414d/native/nginx/PKGBUILD#L80) and not configurable anymore