### PR TITLE
fix: wrong folder name where to download local signatures

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.clamav.signature.provider.template
+++ b/conf/nginx/templates/nginx.conf.web.clamav.signature.provider.template
@@ -15,7 +15,7 @@ server
     }
 
     location ^~ /av_signature {
-        alias /opt/zextras/av_signature/;
+        alias /opt/zextras/av_signatures/;
         allow 127.0.0.1;
         allow ::1;
         deny all;

--- a/conf/nginx/templates/nginx.conf.web.clamav.signature.provider.template
+++ b/conf/nginx/templates/nginx.conf.web.clamav.signature.provider.template
@@ -14,7 +14,7 @@ server
         deny all;
     }
 
-    location ^~ /av_signature {
+    location ^~ /av_signatures {
         alias /opt/zextras/av_signatures/;
         allow 127.0.0.1;
         allow ::1;


### PR DESCRIPTION
According to https://github.com/zextras/carbonio-avdb-updater/pull/29
Changed directory name:
from  av_signature
to av_signatures