### PR TITLE
fix order of ssl certs exposed for imaps/pop3s

### DIFF
--- a/conf/nginx/templates/nginx.conf.mail.template
+++ b/conf/nginx/templates/nginx.conf.mail.template
@@ -287,12 +287,13 @@ mail
     # SSL ECDH cipher curve configuration
     ssl_ecdh_curve          ${mail.ssl.ecdh.curve};
 
-    ${mail.imap.enabled} include ${core.includes}/${core.cprefix}.mail.imap;
     ${mail.imap.enabled} include ${core.includes}/${core.cprefix}.mail.imap.default;
-    ${mail.imaps.enabled} include ${core.includes}/${core.cprefix}.mail.imaps;
+    ${mail.imap.enabled} include ${core.includes}/${core.cprefix}.mail.imap;
     ${mail.imaps.enabled} include ${core.includes}/${core.cprefix}.mail.imaps.default;
-    ${mail.pop3.enabled} include ${core.includes}/${core.cprefix}.mail.pop3;
+    ${mail.imaps.enabled} include ${core.includes}/${core.cprefix}.mail.imaps;
     ${mail.pop3.enabled} include ${core.includes}/${core.cprefix}.mail.pop3.default;
-    ${mail.pop3s.enabled} include ${core.includes}/${core.cprefix}.mail.pop3s;
+    ${mail.pop3.enabled} include ${core.includes}/${core.cprefix}.mail.pop3;
     ${mail.pop3s.enabled} include ${core.includes}/${core.cprefix}.mail.pop3s.default;
+    ${mail.pop3s.enabled} include ${core.includes}/${core.cprefix}.mail.pop3s;
+
 }


### PR DESCRIPTION
This was tested using a custom template on DF since release 24.9, please merge it for version 24.12