### PR TITLE
feat: [CO-2051] add /robots.txt to keep web crawlers out

### DIFF
--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -90,8 +90,8 @@ server
 
     location = /robots.txt
     {
-        default_type text/plain;
-        return 200 "User-agent: *\nDisallow: /\n";
+      default_type text/plain;
+      return 200 "User-agent: *\nDisallow: /\n";
     }
 
     location = /favicon.ico

--- a/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -88,6 +88,12 @@ server
         set $login_upstream    https://zimbra_ssl_webclient;
     }
 
+    location = /robots.txt
+    {
+        default_type text/plain;
+        return 200 "User-agent: *\nDisallow: /\n";
+    }
+
     location = /favicon.ico
     {
       return 404;

--- a/conf/nginx/templates/nginx.conf.web.https.template
+++ b/conf/nginx/templates/nginx.conf.web.https.template
@@ -50,6 +50,12 @@ server
       }
     }
 
+    location = /robots.txt
+    {
+      default_type text/plain;
+      return 200 "User-agent: *\nDisallow: /\n";
+    }
+
     location = /favicon.ico
     {
       return 404;


### PR DESCRIPTION
- RobotsServlet was removed from the mailbox but we decided to keep /robots.txt and keep web crawlers out (old default behavior) for the whole infrastructure, not just the /service endpoint

See: https://github.com/zextras/carbonio-mailbox/pull/723