### PR TITLE
chore: define proxy dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# TODO: use mailbox container image (be careful it is based on ubuntu noble but we need at least jammy)
+FROM mailbox-local
+USER root
+
+RUN apt update && apt install -y gnupg2 ca-certificates && apt clean \
+&& apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21 \
+&& echo deb https://repo.zextras.io/release/ubuntu jammy main > /etc/apt/sources.list.d/zextras.list \
+&& apt update && apt install -y carbonio-nginx openssl netcat curl && apt clean
+
+RUN mkdir -p /opt/zextras/conf
+RUN mkdir -p /opt/zextras/data/tmp/nginx/client
+RUN mkdir -p /run/carbonio
+RUN mkdir -p /opt/zextras/common/conf
+
+# TODO: is a self-signed certificate required?
+RUN openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 \
+-nodes -keyout /opt/zextras/conf/nginx-carbonio.key \
+-out /opt/zextras/conf/nginx-carbonio.crt -subj "/CN=example.com" \
+-addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1"
+
+COPY conf /opt/zextras/conf
+
+COPY entrypoint.sh entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY entrypoint.sh entrypoint.sh
 COPY conf /opt/zextras/conf
 ENV MEMCACHED_BIND_ADDRESS="memcached"
 ENV MEMCACHED_BIND_PORT=11211
-ARG JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
+ARG PROXY_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
               -Dhttps.protocols=TLSv1.2,TLSv1.3 \
               -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 \
               -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true \
@@ -36,6 +36,6 @@ RUN apt update && apt install -y gnupg2 ca-certificates && apt clean \
 -out /opt/zextras/conf/nginx.crt -subj "/CN=example.com" \
 -addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1" \
 && mkdir -p /opt/zextras/conf/nginx/includes && touch /opt/zextras/conf/nginx/includes/nginx.conf.main \
-&& echo "java $JAVA_ARGS com.zimbra.cs.util.proxyconfgen.ProxyConfGen \"\$@\"" > /usr/bin/zmproxyconfgen
+&& echo "java $PROXY_JAVA_ARGS com.zimbra.cs.util.proxyconfgen.ProxyConfGen \"\$@\"" > /usr/bin/zmproxyconfgen
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# TODO: use mailbox container image (be careful it is based on ubuntu noble but we need at least jammy)
-FROM mailbox-local
+FROM registry.dev.zextras.com/dev/carbonio-mailbox:latest
 USER root
 
 RUN apt update && apt install -y gnupg2 ca-certificates && apt clean \
@@ -14,8 +13,8 @@ RUN mkdir -p /opt/zextras/common/conf
 
 # TODO: is a self-signed certificate required?
 RUN openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 \
--nodes -keyout /opt/zextras/conf/nginx-carbonio.key \
--out /opt/zextras/conf/nginx-carbonio.crt -subj "/CN=example.com" \
+-nodes -keyout /opt/zextras/conf/nginx.key \
+-out /opt/zextras/conf/nginx.crt -subj "/CN=example.com" \
 -addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1"
 
 COPY conf /opt/zextras/conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN apt update && apt install -y gnupg2 ca-certificates && apt clean \
 -out /opt/zextras/conf/nginx.crt -subj "/CN=example.com" \
 -addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1" \
 && mkdir -p /opt/zextras/conf/nginx/includes && touch /opt/zextras/conf/nginx/includes/nginx.conf.main \
-&& echo "daemon off;" >> /opt/zextras/conf/nginx/templates/nginx.conf.template \
 && echo "java $JAVA_ARGS com.zimbra.cs.util.proxyconfgen.ProxyConfGen \"\$@\"" > /usr/bin/zmproxyconfgen
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,42 @@
 FROM registry.dev.zextras.com/dev/carbonio-mailbox:latest
 USER root
 
+COPY entrypoint.sh entrypoint.sh
+COPY conf /opt/zextras/conf
+ENV MEMCACHED_BIND_ADDRESS="memcached"
+ENV MEMCACHED_BIND_PORT=11211
+ARG JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
+              -Dhttps.protocols=TLSv1.2,TLSv1.3 \
+              -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 \
+              -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true \
+              -Dsun.net.inetaddr.ttl=60 -Dorg.apache.jasper.compiler.disablejsr199=true \
+              -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:+UnlockExperimentalVMOptions \
+              -XX:G1NewSizePercent=15 -XX:G1MaxNewSizePercent=45 -XX:-OmitStackTraceInFastThrow \
+              -Djava.security.egd=file:/dev/./urandom \
+              --add-opens java.base/java.lang=ALL-UNNAMED \
+              -Xss256k -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
+              -Xms1996m -Xmx1996m -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
+              -Djava.library.path=/opt/zextras/lib \
+              -Dzimbra.config=/localconfig/localconfig.xml \
+              -Dzimbra.native.required=false \
+              -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
+              -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/*"
+
+
 RUN apt update && apt install -y gnupg2 ca-certificates && apt clean \
 && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21 \
 && echo deb https://repo.zextras.io/release/ubuntu jammy main > /etc/apt/sources.list.d/zextras.list \
-&& apt update && apt install -y carbonio-nginx openssl netcat curl && apt clean
-
-RUN mkdir -p /opt/zextras/conf
-RUN mkdir -p /opt/zextras/data/tmp/nginx/client
-RUN mkdir -p /run/carbonio
-RUN mkdir -p /opt/zextras/common/conf
-
-# TODO: is a self-signed certificate required?
-RUN openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 \
+&& apt update && apt install -y carbonio-nginx openssl netcat curl && apt clean \
+&& mkdir -p /opt/zextras/conf \
+&& mkdir -p /opt/zextras/data/tmp/nginx/client \
+&& mkdir -p /run/carbonio \
+&& mkdir -p /opt/zextras/common/conf \
+&& openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 \
 -nodes -keyout /opt/zextras/conf/nginx.key \
 -out /opt/zextras/conf/nginx.crt -subj "/CN=example.com" \
--addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1"
+-addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1" \
+&& mkdir -p /opt/zextras/conf/nginx/includes && touch /opt/zextras/conf/nginx/includes/nginx.conf.main \
+&& echo "daemon off;" >> /opt/zextras/conf/nginx/templates/nginx.conf.template \
+&& echo "java $JAVA_ARGS com.zimbra.cs.util.proxyconfgen.ProxyConfGen \"\$@\"" > /usr/bin/zmproxyconfgen
 
-COPY conf /opt/zextras/conf
-
-COPY entrypoint.sh entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,4 +33,4 @@ echo "Testing Nginx configuration"
 /opt/zextras/common/sbin/nginx -t
 echo "Nginx configuration is ok!"
 
-/opt/zextras/common/sbin/nginx -c /opt/zextras/conf/nginx.conf
+/opt/zextras/common/sbin/nginx -c /opt/zextras/conf/nginx.conf -g "daemon off;"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,8 +29,4 @@ chmod +x /usr/bin/zmproxyconfgen
 
 /usr/bin/zmproxyconfgen
 
-echo "Testing Nginx configuration"
-/opt/zextras/common/sbin/nginx -t
-echo "Nginx configuration is ok!"
-
 /opt/zextras/common/sbin/nginx -c /opt/zextras/conf/nginx.conf -g "daemon off;"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+sed -i -e "s#LDAP_URL#${LDAP_URL}#g" /localconfig/localconfig.xml
+sed -i -e "s/LDAP_ROOT_PASSWORD/${LDAP_ROOT_PASSWORD}/g" /localconfig/localconfig.xml
+sed -i -e "s/LDAP_ADMIN_PASSWORD/${LDAP_ADMIN_PASSWORD}/g" /localconfig/localconfig.xml
+sed -i -e "s/MARIADB_ROOT_PASSWORD/${MARIADB_ROOT_PASSWORD}/g" /localconfig/localconfig.xml
+sed -i -e "s/MARIADB_URL/${MARIADB_URL}/g" /localconfig/localconfig.xml
+sed -i -e "s/MARIADB_PORT/${MARIADB_PORT}/g" /localconfig/localconfig.xml
+sed -i -e "s/SERVER_HOSTNAME/${HOSTNAME}/g" /localconfig/localconfig.xml
+
+SERVER_EXISTS=$(/usr/bin/zmprov -l gs "${HOSTNAME}" 2>&1)
+if [[ $SERVER_EXISTS == *"account.NO_SUCH_SERVER"* ]]; then
+  echo "Creating server ${HOSTNAME}"
+  /usr/bin/zmprov -l cs "${HOSTNAME}" zimbraServiceInstalled proxy zimbraServiceEnabled proxy
+  echo "Server ${HOSTNAME} created"
+fi
+
+# TODO: expose java base args from mailbox container
+ARGS="-Dfile.encoding=UTF-8 -server \
+              -Dhttps.protocols=TLSv1.2,TLSv1.3 \
+              -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 \
+              -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true \
+              -Dsun.net.inetaddr.ttl=60 -Dorg.apache.jasper.compiler.disablejsr199=true \
+              -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:+UnlockExperimentalVMOptions \
+              -XX:G1NewSizePercent=15 -XX:G1MaxNewSizePercent=45 -XX:-OmitStackTraceInFastThrow \
+              -Djava.security.egd=file:/dev/./urandom \
+              --add-opens java.base/java.lang=ALL-UNNAMED \
+              -Xss256k -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
+              -Xms1996m -Xmx1996m -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
+              -Djava.library.path=/opt/zextras/lib \
+              -Dzimbra.config=/localconfig/localconfig.xml \
+              -Dzimbra.native.required=false \
+              -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
+              -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/*"
+
+echo "java $ARGS com.zimbra.cs.util.proxyconfgen.ProxyConfGen \"\$@\"" > /usr/bin/zmproxyconfgen
+
+chmod +x /usr/bin/zmproxyconfgen
+
+/usr/bin/zmproxyconfgen
+
+# TODO: nginx requires memcached
+# WARN : No available nginx lookup handlers could be found
+# INFO : Strict server name enforcement enabled? true
+# ERROR: Error while expanding templates: No available memcached servers could be contacted
+/opt/zextras/common/sbin/nginx -c /opt/zextras/conf/nginx.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,36 +11,26 @@ sed -i -e "s/SERVER_HOSTNAME/${HOSTNAME}/g" /localconfig/localconfig.xml
 SERVER_EXISTS=$(/usr/bin/zmprov -l gs "${HOSTNAME}" 2>&1)
 if [[ $SERVER_EXISTS == *"account.NO_SUCH_SERVER"* ]]; then
   echo "Creating server ${HOSTNAME}"
-  /usr/bin/zmprov -l cs "${HOSTNAME}" zimbraServiceInstalled proxy zimbraServiceEnabled proxy
+  /usr/bin/zmprov -l cs "${HOSTNAME}" zimbraServiceInstalled proxy \
+                                      zimbraServiceEnabled proxy \
+                                      zimbraServiceInstalled memcached \
+                                      zimbraServiceEnabled memcached \
+                                      zimbraMemcachedBindAddress "${MEMCACHED_BIND_ADDRESS}" \
+                                      zimbraMemcachedBindPort "${MEMCACHED_BIND_PORT}" \
+                                      zimbraMailProxyPort 80 \
+                                      zimbraMailSSLProxyPort 443 \
+                                      zimbraReverseProxyStrictServerNameEnabled FALSE
+
   echo "Server ${HOSTNAME} created"
 fi
 
-# TODO: expose java base args from mailbox container
-ARGS="-Dfile.encoding=UTF-8 -server \
-              -Dhttps.protocols=TLSv1.2,TLSv1.3 \
-              -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 \
-              -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true \
-              -Dsun.net.inetaddr.ttl=60 -Dorg.apache.jasper.compiler.disablejsr199=true \
-              -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:+UnlockExperimentalVMOptions \
-              -XX:G1NewSizePercent=15 -XX:G1MaxNewSizePercent=45 -XX:-OmitStackTraceInFastThrow \
-              -Djava.security.egd=file:/dev/./urandom \
-              --add-opens java.base/java.lang=ALL-UNNAMED \
-              -Xss256k -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
-              -Xms1996m -Xmx1996m -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
-              -Djava.library.path=/opt/zextras/lib \
-              -Dzimbra.config=/localconfig/localconfig.xml \
-              -Dzimbra.native.required=false \
-              -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
-              -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/*"
-
-echo "java $ARGS com.zimbra.cs.util.proxyconfgen.ProxyConfGen \"\$@\"" > /usr/bin/zmproxyconfgen
 
 chmod +x /usr/bin/zmproxyconfgen
 
 /usr/bin/zmproxyconfgen
 
-# TODO: nginx requires memcached
-# WARN : No available nginx lookup handlers could be found
-# INFO : Strict server name enforcement enabled? true
-# ERROR: Error while expanding templates: No available memcached servers could be contacted
+echo "Testing Nginx configuration"
+/opt/zextras/common/sbin/nginx -t
+echo "Nginx configuration is ok!"
+
 /opt/zextras/common/sbin/nginx -c /opt/zextras/conf/nginx.conf


### PR DESCRIPTION
This container is based on mailbox dev container, as it needs mailbox jars to run zmproxyconfgen.

It uses carbonio-nginx from release + adds the files under conf.
At runtime the container creates a proxy server with proxy and memcached services installed, expands the templates and starts with daemon off.
In order to use this container nginx-zmlookup is required (it has been added to mailbox in: https://github.com/zextras/carbonio-mailbox/pull/759) and also a memcached instance is required.

We tested it successfully locally, but few things are required in order to use it:
- mailbox with zmlookup
- memcached
- (optional) no webui is provided, this is only the proxy configuration. If you need a webui you have several options, like running apt install carbonio-webui in the container manually or define a webui container on top of this.