### PR TITLE
chore (ci): upgrade to jenkins-packages-build-library@1.0.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-packages-build-library@1.0.0',
+    identifier: 'jenkins-packages-build-library@1.0.1',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
@@ -65,11 +65,13 @@ pipeline {
                     withDockerRegistry(credentialsId: 'private-registry', url: 'https://registry.dev.zextras.com') {
                         script {
                             dockerHelper.buildImage([
-                                title: 'Carbonio Proxy', 
-                                description: 'Carbonio Proxy container',
                                 dockerfile: 'Dockerfile',
                                 imageName: 'registry.dev.zextras.com/dev/carbonio-proxy',
-                                tags: ['latest']
+                                tags: ['latest'],
+                                ocLabels: [
+                                    title: 'Carbonio Proxy', 
+                                    description: 'Carbonio Proxy container',
+                                ]
                             ])
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-packages-build-library@chore/IN-930',
+    identifier: 'jenkins-packages-build-library@1.0.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-packages-build-library.git',

--- a/yap.json
+++ b/yap.json
@@ -1,9 +1,9 @@
 {
     "name": "An open-source, community-driven email server",
-    "Description": "The test description",
+    "description": "The test description",
     "buildDir": "/tmp",
     "output": "artifacts",
-    "Projects": [
+    "projects": [
         {
             "name": "proxy"
         }


### PR DESCRIPTION
This PR updates the Jenkins pipeline to use the newly released jenkins-packages-build-library v1.0.0, which introduces major improvements to our build infrastructure:

Key Benefits:

1. reduce duplicated code
2. centralized configuration for supported platforms (ubuntu-jammy, ubuntu-noble etc.)
3. reutilize the playground rt project to test the pipeline release flow

These changes significantly reduce pipeline complexity while making builds more maintainable and reliable across all Zextras repositories.