### PR TITLE
ci: update jenkins-lib-common to 1.5.0 and add -d build flag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.4.0',
+    identifier: 'jenkins-lib-common@1.5.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',
@@ -125,7 +125,7 @@ pipeline {
             steps {
                 echo 'Building deb/rpm packages'
                 buildStage([
-                    buildFlags: ' -s '
+                    buildFlags: ' -ds '
                 ])
             }
         }


### PR DESCRIPTION
## Summary

- Bump `jenkins-lib-common` library version from `1.4.0` to `1.5.0`
- Add `-d` flag to `buildFlags` in the `Build deb/rpm` stage so yap skips resolving `makedepends` from PKGBUILD at compile time (those dependencies are runtime-only)