### PR TITLE
fix(proxy): force HTTP/1.0 + Connection close on mailbox upstreams

### DIFF
--- a/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
@@ -136,5 +136,7 @@ server
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
     }
 }

--- a/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
@@ -137,5 +137,7 @@ server
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
     }
 }

--- a/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
@@ -324,6 +324,8 @@ server
 
         # Proxy to Login Upstream
         proxy_pass       $login_upstream;
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -379,6 +381,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.polling.timeout};
         proxy_buffering     off;
 
@@ -425,6 +429,8 @@ server
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
     }
 
     location ~* /service/extension/drive/(.*)/(.*)$
@@ -456,6 +462,8 @@ server
 
         # Proxy to Zimbra Upstream servers, with large buffers
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.noop.timeout};
 
         # For audit
@@ -517,6 +525,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.noop.timeout};
         proxy_buffering     off;
 
@@ -572,6 +582,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.waitset.timeout};
         proxy_buffering     off;
 
@@ -631,6 +643,8 @@ server
 
         # Proxy to Zimbra Mailbox Upstream
         proxy_pass       $autodiscover_upstream;
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -667,6 +681,8 @@ server
     ${web.ews.upstream.disable} {
     ${web.ews.upstream.disable}     # Proxy to Zimbra Upstream
     ${web.ews.upstream.disable}     proxy_pass          ${web.upstream.ews.target};
+    ${web.ews.upstream.disable}     proxy_http_version 1.0;
+    ${web.ews.upstream.disable}     proxy_set_header  Connection close;
     ${web.ews.upstream.disable}     proxy_read_timeout  ${web.upstream.polling.timeout};
     ${web.ews.upstream.disable}     proxy_buffering     off;
     ${web.ews.upstream.disable}
@@ -726,6 +742,8 @@ server
 
         # Proxy to Zimbra Mailbox Upstream
         proxy_pass       ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/proxy/conf/nginx/templates/nginx.conf.web.http.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.template
@@ -298,6 +298,8 @@ server
 
         # Proxy to Login Upstream
         proxy_pass       $login_upstream;
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -352,6 +354,8 @@ server
 
         # Proxy to Zimbra Webclient Upstream
         proxy_pass       ${web.upstream.webclient.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -405,6 +409,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.polling.timeout};
         proxy_buffering     off;
 
@@ -451,6 +457,8 @@ server
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
     }
 
     location ~* /service/extension/drive/(.*)/(.*)$
@@ -482,6 +490,8 @@ server
 
         # Proxy to Zimbra Upstream servers, with large buffers
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.noop.timeout};
 
         # For audit
@@ -543,6 +553,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.noop.timeout};
         proxy_buffering     off;
 
@@ -598,6 +610,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.waitset.timeout};
         proxy_buffering     off;
 
@@ -657,6 +671,8 @@ server
 
         # Proxy to Zimbra Mailbox Upstream
         proxy_pass       $autodiscover_upstream;
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -693,6 +709,8 @@ server
     ${web.ews.upstream.disable} {
     ${web.ews.upstream.disable}     # Proxy to Zimbra Upstream
     ${web.ews.upstream.disable}     proxy_pass          ${web.upstream.ews.target};
+    ${web.ews.upstream.disable}     proxy_http_version 1.0;
+    ${web.ews.upstream.disable}     proxy_set_header  Connection close;
     ${web.ews.upstream.disable}     proxy_read_timeout  ${web.upstream.polling.timeout};
     ${web.ews.upstream.disable}     proxy_buffering     off;
     ${web.ews.upstream.disable}
@@ -752,6 +770,8 @@ server
 
         # Proxy to Zimbra Mailbox Upstream
         proxy_pass       ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -348,6 +348,8 @@ server
 
         # Proxy to Login Upstream
         proxy_pass       $login_upstream;
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -403,6 +405,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.polling.timeout};
         proxy_buffering     off;
 
@@ -449,6 +453,8 @@ server
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
     }
 
     location ~* /service/extension/drive/(.*)/(.*)$
@@ -480,6 +486,8 @@ server
 
         # Proxy to Zimbra Upstream servers, with large buffers
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.noop.timeout};
 
         # For audit
@@ -541,6 +549,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.noop.timeout};
         proxy_buffering     off;
 
@@ -596,6 +606,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.waitset.timeout};
         proxy_buffering     off;
 
@@ -655,6 +667,8 @@ server
 
         # Proxy to Zimbra Mailbox Upstream
         proxy_pass       $autodiscover_upstream;
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -691,6 +705,8 @@ server
     ${web.ews.upstream.disable} {
     ${web.ews.upstream.disable}     # Proxy to Zimbra Upstream
     ${web.ews.upstream.disable}     proxy_pass          ${web.upstream.ews.target};
+    ${web.ews.upstream.disable}     proxy_http_version 1.0;
+    ${web.ews.upstream.disable}     proxy_set_header  Connection close;
     ${web.ews.upstream.disable}     proxy_read_timeout  ${web.upstream.polling.timeout};
     ${web.ews.upstream.disable}     proxy_buffering     off;
     ${web.ews.upstream.disable}
@@ -750,6 +766,8 @@ server
 
         # Proxy to Zimbra Mailbox Upstream
         proxy_pass       ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.template
@@ -310,6 +310,8 @@ server
 
         # Proxy to Login Upstream
         proxy_pass       $login_upstream;
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -364,6 +366,8 @@ server
 
         # Proxy to Zimbra Webclient Upstream
         proxy_pass       ${web.upstream.webclient.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -417,6 +421,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.polling.timeout};
         proxy_buffering     off;
 
@@ -463,6 +469,8 @@ server
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
     }
 
     location ~* /service/extension/drive/(.*)/(.*)$
@@ -494,6 +502,8 @@ server
 
         # Proxy to Zimbra Upstream servers, with large buffers
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.noop.timeout};
 
         # For audit
@@ -555,6 +565,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.noop.timeout};
         proxy_buffering     off;
 
@@ -610,6 +622,8 @@ server
 
         # Proxy to Zimbra Upstream
         proxy_pass          ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
         proxy_read_timeout  ${web.upstream.waitset.timeout};
         proxy_buffering     off;
 
@@ -669,6 +683,8 @@ server
 
         # Proxy to Zimbra Mailbox Upstream
         proxy_pass       $autodiscover_upstream;
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -705,6 +721,8 @@ server
     ${web.ews.upstream.disable} {
     ${web.ews.upstream.disable}     # Proxy to Zimbra Upstream
     ${web.ews.upstream.disable}     proxy_pass          ${web.upstream.ews.target};
+    ${web.ews.upstream.disable}     proxy_http_version 1.0;
+    ${web.ews.upstream.disable}     proxy_set_header  Connection close;
     ${web.ews.upstream.disable}     proxy_read_timeout  ${web.upstream.polling.timeout};
     ${web.ews.upstream.disable}     proxy_buffering     off;
     ${web.ews.upstream.disable}
@@ -764,6 +782,8 @@ server
 
         # Proxy to Zimbra Mailbox Upstream
         proxy_pass       ${web.upstream.target};
+        proxy_http_version 1.0;
+        proxy_set_header  Connection close;
 
         # For audit
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
nginx 1.29.7 changed proxy module defaults: proxy_http_version is now 1.1 and the Connection header is no longer sent. This change shipped in carbonio-nginx 1.30.0 and broke every mailbox/Jetty proxy block in the web templates, which relied on the old 1.28 defaults (HTTP/1.0 + Connection: close). Every other service block already sets proxy_http_version 1.1 explicitly, so only the Jetty paths regress - matching the QA report of HTTP 500 on any request to Jetty.

Restore 1.28 behavior by adding 'proxy_http_version 1.0;' and 'proxy_set_header Connection close;' to each mailbox proxy_pass block (${web.upstream.target}, ${web.upstream.webclient.target}, ${web.upstream.ews.target}, ${web.upstream.zx}, $login_upstream, $autodiscover_upstream). Websocket /zx/ws-* blocks are left untouched because they already set proxy_http_version 1.1 for upgrade support.

40 location blocks patched across 6 templates. Rendered config syntax-validated against carbonio-nginx-1.30.0.

Refs: CO-3548