### PR TITLE
fix(proxy): disable keepalive on zmauth upstream blocks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.6.2',
+    identifier: 'jenkins-lib-common@1.7.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/proxy/conf/nginx/templates/nginx.conf.web.upstreams.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.upstreams.template
@@ -13,6 +13,7 @@
     {
         ${web.upstream.webclient.:servers}
         zmauth;
+        keepalive 0;
     }
 
     #  Define the collection of upstream HTTP servers to which we will proxy
@@ -22,6 +23,7 @@
     {
         ${web.upstream.:servers}
         zmauth;
+        keepalive 0;
     }
 
     #  Define the collection of upstream HTTPS webclient servers to which we will proxy
@@ -31,6 +33,7 @@
     {
         ${web.ssl.upstream.webclient.:servers}
         zmauth;
+        keepalive 0;
     }
 
     #  Define the collection of upstream HTTPS servers to which we will proxy
@@ -39,6 +42,7 @@
     {
         ${web.ssl.upstream.:servers}
         zmauth;
+        keepalive 0;
     }
 
     #  Define the collection of upstream HTTP servers to dedicated zx port of jetty
@@ -46,6 +50,7 @@
     {
         ${web.upstream.zx.:servers}
         zmauth_zx;
+        keepalive 0;
     }
 
     #  Define the collection of upstream HTTPS servers to dedicated zx ssl port of jetty
@@ -53,6 +58,7 @@
     {
         ${web.ssl.upstream.zx.:servers}
         zmauth_zx;
+        keepalive 0;
     }
 
     #  Define the collection of upstream admin client servers to which we will
@@ -62,6 +68,7 @@
     {
         ${web.admin.upstream.adminclient.:servers}
         zmauth_admin;
+        keepalive 0;
     }
 
     #  Define the collection of upstream admin console servers to which we will
@@ -71,6 +78,7 @@
     {
         ${web.admin.upstream.:servers}
         zmauth_admin;
+        keepalive 0;
     }
 
     #  Define the collection of upstream HTTP EWS servers to which we will
@@ -80,6 +88,7 @@
     ${web.ews.upstream.disable} {
     ${web.ews.upstream.disable}    ${web.upstream.ewsserver.:servers}
     ${web.ews.upstream.disable}    zmauth;
+    ${web.ews.upstream.disable}    keepalive 0;
     ${web.ews.upstream.disable} }
 
     #  Define the collection of upstream HTTPS EWS servers to which we will
@@ -89,6 +98,7 @@
     ${web.ews.upstream.disable} {
     ${web.ews.upstream.disable}    ${web.ssl.upstream.ewsserver.:servers}
     ${web.ews.upstream.disable}    zmauth;
+    ${web.ews.upstream.disable}    keepalive 0;
     ${web.ews.upstream.disable} }
 
     #  Define the collection of upstream HTTP Login servers to which we will
@@ -98,6 +108,7 @@
     ${web.login.upstream.disable} {
     ${web.login.upstream.disable}    ${web.upstream.loginserver.:servers}
     ${web.login.upstream.disable}    zmauth;
+    ${web.login.upstream.disable}    keepalive 0;
     ${web.login.upstream.disable} }
 
     #  Define the collection of upstream HTTPS Login servers to which we will
@@ -107,6 +118,7 @@
     ${web.login.upstream.disable} {
     ${web.login.upstream.disable}    ${web.ssl.upstream.loginserver.:servers}
     ${web.login.upstream.disable}    zmauth;
+    ${web.login.upstream.disable}    keepalive 0;
     ${web.login.upstream.disable} }
 
 


### PR DESCRIPTION
nginx 1.30 added an init_main_conf callback to the keepalive module that auto-wraps every upstream block's peer.init with init_keepalive_peer (only skipped when 'keepalive 0;' is set explicitly). nginx 1.28 wrapped only when the 'keepalive N;' directive was present.

The keepalive wrapper at ngx_http_upstream_init_keepalive_peer collapses the original peer.init's return value with 'rc != NGX_OK -> NGX_ERROR'. Carbonio's zmauth peer.init returns NGX_AGAIN when an asynchronous route lookup is posted (memcached / nginx-lookup), and the carbonio patch to ngx_http_upstream_init_request relies on that NGX_AGAIN to defer finalization. With nginx 1.30's auto-wrap in place, NGX_AGAIN becomes NGX_ERROR and every authenticated request that needs an async route lookup is finalized with HTTP 500.

Add 'keepalive 0;' next to each zmauth/zmauth_zx/zmauth_admin directive so the keepalive module's init_main_conf hits its 'continue' branch for those upstreams and the auto-wrap is skipped. The mailbox path keeps using zmauth's own peer machinery directly.

Refs: CO-3548