### PR TITLE
chore: use devel upstream to install nginx packages (requires auth.conf + fix for service discover resolvconf)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN --mount=type=bind,source=auth.conf,target=/etc/apt/auth.conf \
         echo 'deb [trusted=yes] https://zextras.jfrog.io/artifactory/ubuntu-devel jammy main' \
     > /etc/apt/sources.list.d/zextras.list \
  && apt update \
+ && dpkg-divert --local --rename --add /usr/sbin/resolvconf \
+ && ln -sf /bin/true /usr/sbin/resolvconf \
  && apt install -y gnupg2 \
         ca-certificates openssl netcat curl carbonio-nginx \
  && apt clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,10 @@ ARG PROXY_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
 
 COPY local-debs/carbonio-nginx_*.deb /tmp/
 
-RUN apt update && apt install -y openssl netcat curl ca-certificates /tmp/carbonio-nginx_*.deb && apt clean \
+RUN apt update && apt install -y gnupg2 ca-certificates && apt clean \
+&& apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21 \
+&& echo deb https://repo.zextras.io/release/ubuntu jammy main > /etc/apt/sources.list.d/zextras.list \
+&& apt update && apt install -y openssl netcat curl /tmp/carbonio-nginx_*.deb && apt clean \
 && rm /tmp/carbonio-nginx_*.deb \
 && mkdir -p /opt/zextras/conf \
 && mkdir -p /opt/zextras/data/tmp/nginx/client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,10 @@ ARG PROXY_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
               -cp /opt/zextras/proxyconfgen/proxyconfgen.jar"
 
 
-RUN apt update && apt install -y gnupg2 ca-certificates && apt clean \
-&& apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21 \
-&& echo deb https://repo.zextras.io/release/ubuntu jammy main > /etc/apt/sources.list.d/zextras.list \
-&& apt update && apt install -y carbonio-nginx openssl netcat curl && apt clean \
+COPY local-debs/carbonio-nginx_*.deb /tmp/
+
+RUN apt update && apt install -y openssl netcat curl ca-certificates /tmp/carbonio-nginx_*.deb && apt clean \
+&& rm /tmp/carbonio-nginx_*.deb \
 && mkdir -p /opt/zextras/conf \
 && mkdir -p /opt/zextras/data/tmp/nginx/client \
 && mkdir -p /run/carbonio \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN --mount=type=bind,source=auth.conf,target=/etc/apt/auth.conf \
  && apt update \
  && echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections \
  && apt install -y gnupg2 \
-        ca-certificates openssl netcat curl carbonio-nginx \
+        ca-certificates openssl jq wget unzip netcat curl carbonio-nginx \
  && apt clean \
  && mkdir -p /opt/zextras/conf \
  && mkdir -p /opt/zextras/data/tmp/nginx/client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,7 @@ RUN --mount=type=bind,source=auth.conf,target=/etc/apt/auth.conf \
         echo 'deb [trusted=yes] https://zextras.jfrog.io/artifactory/ubuntu-devel jammy main' \
     > /etc/apt/sources.list.d/zextras.list \
  && apt update \
- && dpkg-divert --local --rename --add /usr/sbin/resolvconf \
- && ln -sf /bin/true /usr/sbin/resolvconf \
+ && echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections \
  && apt install -y gnupg2 \
         ca-certificates openssl netcat curl carbonio-nginx \
  && apt clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM registry.dev.zextras.com/dev/carbonio-mailbox:devel
 USER root
 
@@ -36,23 +37,23 @@ ARG PROXY_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
               -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
               -cp /opt/zextras/proxyconfgen/proxyconfgen.jar"
 
-
-COPY local-debs/carbonio-nginx_*.deb /tmp/
-
-RUN apt update && apt install -y gnupg2 ca-certificates && apt clean \
-&& apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21 \
-&& echo deb https://repo.zextras.io/release/ubuntu jammy main > /etc/apt/sources.list.d/zextras.list \
-&& apt update && apt install -y openssl netcat curl /tmp/carbonio-nginx_*.deb && apt clean \
-&& rm /tmp/carbonio-nginx_*.deb \
-&& mkdir -p /opt/zextras/conf \
-&& mkdir -p /opt/zextras/data/tmp/nginx/client \
-&& mkdir -p /run/carbonio \
-&& mkdir -p /opt/zextras/common/conf \
-&& openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 \
--nodes -keyout /opt/zextras/conf/nginx.key \
--out /opt/zextras/conf/nginx.crt -subj "/CN=example.com" \
--addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1" \
-&& mkdir -p /opt/zextras/conf/nginx/includes && touch /opt/zextras/conf/nginx/includes/nginx.conf.main \
-&& echo "java $PROXY_JAVA_ARGS com.zimbra.cs.util.proxyconfgen.ProxyConfGen \"\$@\"" > /usr/bin/zmproxyconfgen
+RUN --mount=type=bind,source=auth.conf,target=/etc/apt/auth.conf \
+        echo 'deb [trusted=yes] https://zextras.jfrog.io/artifactory/ubuntu-devel jammy main' \
+    > /etc/apt/sources.list.d/zextras.list \
+ && apt update \
+ && apt install -y gnupg2 \
+        ca-certificates openssl netcat curl carbonio-nginx \
+ && apt clean \
+ && mkdir -p /opt/zextras/conf \
+ && mkdir -p /opt/zextras/data/tmp/nginx/client \
+ && mkdir -p /run/carbonio \
+ && mkdir -p /opt/zextras/common/conf \
+ && openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 \
+        -nodes -keyout /opt/zextras/conf/nginx.key \
+        -out /opt/zextras/conf/nginx.crt -subj "/CN=example.com" \
+        -addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1" \
+ && mkdir -p /opt/zextras/conf/nginx/includes \
+ && touch /opt/zextras/conf/nginx/includes/nginx.conf.main \
+ && echo "java $PROXY_JAVA_ARGS com.zimbra.cs.util.proxyconfgen.ProxyConfGen \"\$@\"" > /usr/bin/zmproxyconfgen
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
             steps {
                 script {
                     withCredentials([usernamePassword(
-                        credentialsId: 'zextras-jfrog',
+                        credentialsId: 'artifactory-jenkins-gradle-properties-splitted',
                         usernameVariable: 'USERNAME',
                         passwordVariable: 'SECRET'
                     )]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,24 @@ pipeline {
             }
         }
 
+        stage('Fetch carbonio-nginx from Artifactory') {
+            steps {
+                script {
+                    def server = Artifactory.server('zextras-artifactory')
+                    server.download(spec: '''{
+                        "files": [{
+                            "pattern": "ubuntu-devel/pool/carbonio-nginx_*jammy_amd64.deb",
+                            "target": "local-debs/",
+                            "flat": "true",
+                            "sortBy": ["created"],
+                            "sortOrder": "desc",
+                            "limit": 1
+                        }]
+                    }''')
+                }
+            }
+        }
+
         stage('Docker build') {
             steps {
                 dockerStage([

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,53 +54,42 @@ pipeline {
             }
         }
 
-        stage('Fetch carbonio-nginx from Artifactory') {
+        stage('Publish containers') {
             steps {
                 script {
-                    def server = Artifactory.server('zextras-artifactory')
-                    server.download(spec: '''{
-                        "files": [{
-                            "pattern": "ubuntu-devel/pool/carbonio-nginx_*jammy_amd64.deb",
-                            "target": "local-debs/",
-                            "flat": "true",
-                            "sortBy": ["created"],
-                            "sortOrder": "desc",
-                            "limit": 1
-                        }]
-                    }''')
+                    withCredentials([usernamePassword(
+                        credentialsId: 'zextras-jfrog',
+                        usernameVariable: 'USERNAME',
+                        passwordVariable: 'SECRET'
+                    )]) {
+                        sh '''
+set +x
+cat > auth.conf <<EOF
+machine zextras.jfrog.io
+login $USERNAME
+password $SECRET
+EOF
+'''
+                        try {
+                            dockerStage([
+                                    dockerfile: 'Dockerfile',
+                                    imageName : 'carbonio-proxy',
+                                    ocLabels  : [
+                                            title : 'Carbonio Proxy'
+                                    ]
+                            ])
+                            dockerStage([
+                                    dockerfile: 'Dockerfile-sidecar',
+                                    imageName : 'carbonio-proxy-sidecar',
+                                    ocLabels  : [
+                                            title : 'Carbonio Proxy Sidecar'
+                                    ]
+                            ])
+                        } finally {
+                            sh 'rm -f auth.conf'
+                        }
+                    }
                 }
-            }
-        }
-
-        stage('Docker build') {
-            steps {
-                dockerStage([
-                        dockerfile: 'Dockerfile',
-                        imageName : 'carbonio-proxy',
-                        ocLabels  : [
-                                title : 'Carbonio Proxy'
-                        ]
-                ])
-                dockerStage([
-                        dockerfile: 'Dockerfile-sidecar',
-                        imageName : 'carbonio-proxy-sidecar',
-                        ocLabels  : [
-                                title : 'Carbonio Proxy Sidecar'
-                        ]
-                ])
-            }
-        }
-
-        stage('Publish containers - devel') {
-            steps {
-                dockerStage([
-                    dockerfile: 'Dockerfile',
-                    imageName: 'carbonio-proxy',
-                    ocLabels: [
-                        title: 'Carbonio Proxy',
-                        description: 'Carbonio Proxy container',
-                    ]
-                ])
             }
         }
 


### PR DESCRIPTION
Currently carbonio-nginx release is at 1.28 and not compatible with latest changes in this repo.

We never used carbonio-nginx devel directly because:
- we need the private key of artifactory in order to use the devel upstream
- we do not have images of carbonio-nginx

I thought about few options:
- modify carbonio-thirds to publish images, but requires to rethink the CI and discuss few things
- clone carbonio-thirds and build locally (build is long)
- clone the deb from devel in artifactory -> I think it would work, but we end up with nginx from devel and other packages from release
- add devel + jfrog credentials or artifactory and install packages

I found some issues with resolvconf but found a way to bypass them

**Note:** credentials are not stored in the image, but are transient and used only in the build phase