### PR TITLE
feat(IN-951): add arm64 multiarch Docker image support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,14 @@
 # syntax=docker/dockerfile:1.4
-FROM registry.dev.zextras.com/dev/carbonio-mailbox:devel
-USER root
 
-COPY target/proxyconfgen.jar /opt/zextras/proxyconfgen/proxyconfgen.jar
+# Stage 1: runs natively on BUILDPLATFORM (amd64 CI builder) — no QEMU.
+# Downloads carbonio-nginx + runtime libs for TARGETARCH via apt-get download
+# (no dep resolution, no postinst scripts, no service-discover/resolvconf).
+# Also pre-generates the self-signed cert and zmproxyconfgen wrapper so the
+# final stage needs zero RUN steps.
+FROM --platform=$BUILDPLATFORM ubuntu:jammy AS nginx-installer
 
-COPY entrypoint.sh entrypoint.sh
-COPY proxy/conf /opt/zextras/conf
-ENV MEMCACHED_BIND_ADDRESS="memcached"
-ENV MEMCACHED_BIND_PORT=11211
-ENV CARBONIO_FILES_HOST="127.78.0.1:20000"
-ENV CARBONIO_WSC_HOST="127.78.0.1:20001"
-ENV CARBONIO_DOCS_CONNECTOR_HOST="127.78.0.1:20002"
-ENV CARBONIO_DOCS_EDITOR_HOST="127.78.0.1:20003"
-ENV CARBONIO_MESSAGE_DISPATCHER_HOST="127.78.0.1:20004"
-ENV CARBONIO_TASKS_HOST="127.78.0.1:20007"
-ENV CARBONIO_AUTH_HOST="127.78.0.1:20008"
-ENV CARBONIO_STORAGES_HOST="127.78.0.1:20009"
-ENV CARBONIO_NOTIFICATION_PUSH_HOST="127.78.0.1:20010"
-ENV CARBONIO_CERTIFICATE_MANAGER_HOST="127.78.0.1:20011"
-ENV CARBONIO_CATALOG_HOST="127.78.0.1:20012"
-
+ARG TARGETARCH
+ARG BUILDARCH=amd64
 ARG PROXY_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
               -Dhttps.protocols=TLSv1.2,TLSv1.3 \
               -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 \
@@ -37,24 +26,78 @@ ARG PROXY_JAVA_ARGS="-Dfile.encoding=UTF-8 -server \
               -Dlog4j.configurationFile=/opt/zextras/conf/log4j.properties \
               -cp /opt/zextras/proxyconfgen/proxyconfgen.jar"
 
-RUN --mount=type=bind,source=auth.conf,target=/etc/apt/auth.conf \
-        echo 'deb [trusted=yes] https://zextras.jfrog.io/artifactory/ubuntu-devel jammy main' \
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates openssl \
+ # Cross-arch setup when TARGETARCH != BUILDARCH
+ && if [ "${TARGETARCH}" != "${BUILDARCH}" ]; then \
+      dpkg --add-architecture ${TARGETARCH} \
+      && sed -i 's|^deb |deb [arch='"${BUILDARCH}"'] |' /etc/apt/sources.list \
+      && printf 'Types: deb\nURIs: http://ports.ubuntu.com/ubuntu-ports/\nSuites: jammy jammy-updates jammy-security\nComponents: main restricted universe multiverse\nArchitectures: %s\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' "${TARGETARCH}" \
+         > /etc/apt/sources.list.d/ports-${TARGETARCH}.sources; \
+    fi \
+ && printf 'deb [arch=%s trusted=yes] https://repo.area51-zextras.com/devel/ubuntu jammy main\n' "${TARGETARCH}" \
     > /etc/apt/sources.list.d/zextras.list \
- && apt update \
- && echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections \
- && apt install -y gnupg2 \
-        ca-certificates openssl jq wget unzip netcat curl carbonio-nginx \
- && apt clean \
- && mkdir -p /opt/zextras/conf \
- && mkdir -p /opt/zextras/data/tmp/nginx/client \
- && mkdir -p /run/carbonio \
- && mkdir -p /opt/zextras/common/conf \
+ && apt-get update \
+ # Download only the packages needed to run nginx — no dep resolution, no carbonio-core
+ && mkdir -p /staging /tmp/debs && cd /tmp/debs \
+ && apt-get download \
+      carbonio-nginx:${TARGETARCH} \
+      carbonio-openssl:${TARGETARCH} \
+      carbonio-cyrus-sasl:${TARGETARCH} \
+      libbrotli1:${TARGETARCH} \
+      libcap2:${TARGETARCH} \
+      libluajit-5.1-2:${TARGETARCH} \
+      libpcre3:${TARGETARCH} \
+      zlib1g:${TARGETARCH} \
+ # Extract all debs with dpkg -x — no postinst scripts run
+ && for deb in /tmp/debs/*.deb; do dpkg -x "$deb" /staging; done \
+ && rm -rf /tmp/debs \
+ # Collect arch-specific libs into /staging/usr/local/lib for arch-independent COPY
+ && mkdir -p /staging/usr/local/lib \
+ && find /staging/lib /staging/usr/lib -name '*.so*' -not -path '*/opt/*' \
+    -exec cp -P {} /staging/usr/local/lib/ \; 2>/dev/null || true \
+ # Pre-create directories needed at runtime
+ && mkdir -p /staging/opt/zextras/conf/nginx/includes \
+ && mkdir -p /staging/opt/zextras/data/tmp/nginx/client \
+ && mkdir -p /staging/opt/zextras/common/conf \
+ && touch /staging/opt/zextras/conf/nginx/includes/nginx.conf.main \
+ # Generate self-signed cert (runs natively on BUILDPLATFORM)
  && openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 \
-        -nodes -keyout /opt/zextras/conf/nginx.key \
-        -out /opt/zextras/conf/nginx.crt -subj "/CN=example.com" \
+        -nodes -keyout /staging/opt/zextras/conf/nginx.key \
+        -out /staging/opt/zextras/conf/nginx.crt -subj "/CN=example.com" \
         -addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1" \
- && mkdir -p /opt/zextras/conf/nginx/includes \
- && touch /opt/zextras/conf/nginx/includes/nginx.conf.main \
- && echo "java $PROXY_JAVA_ARGS com.zimbra.cs.util.proxyconfgen.ProxyConfGen \"\$@\"" > /usr/bin/zmproxyconfgen
+ # Write zmproxyconfgen wrapper
+ && mkdir -p /staging/usr/bin \
+ && echo "java ${PROXY_JAVA_ARGS} com.zimbra.cs.util.proxyconfgen.ProxyConfGen \"\$@\"" \
+    > /staging/usr/bin/zmproxyconfgen \
+ && chmod +x /staging/usr/bin/zmproxyconfgen \
+ && rm -rf /var/lib/apt/lists/*
+
+# Stage 2: final image — TARGETPLATFORM, zero RUN steps (no QEMU needed).
+FROM --platform=$TARGETPLATFORM registry.dev.zextras.com/dev/carbonio-mailbox:devel
+USER root
+
+COPY target/proxyconfgen.jar /opt/zextras/proxyconfgen/proxyconfgen.jar
+COPY entrypoint.sh entrypoint.sh
+COPY proxy/conf /opt/zextras/conf
+
+ENV MEMCACHED_BIND_ADDRESS="memcached"
+ENV MEMCACHED_BIND_PORT=11211
+ENV CARBONIO_FILES_HOST="127.78.0.1:20000"
+ENV CARBONIO_WSC_HOST="127.78.0.1:20001"
+ENV CARBONIO_DOCS_CONNECTOR_HOST="127.78.0.1:20002"
+ENV CARBONIO_DOCS_EDITOR_HOST="127.78.0.1:20003"
+ENV CARBONIO_MESSAGE_DISPATCHER_HOST="127.78.0.1:20004"
+ENV CARBONIO_TASKS_HOST="127.78.0.1:20007"
+ENV CARBONIO_AUTH_HOST="127.78.0.1:20008"
+ENV CARBONIO_STORAGES_HOST="127.78.0.1:20009"
+ENV CARBONIO_NOTIFICATION_PUSH_HOST="127.78.0.1:20010"
+ENV CARBONIO_CERTIFICATE_MANAGER_HOST="127.78.0.1:20011"
+ENV CARBONIO_CATALOG_HOST="127.78.0.1:20012"
+
+COPY --from=nginx-installer /staging/opt /opt
+COPY --from=nginx-installer /staging/usr/local/lib /usr/local/lib/
+COPY --from=nginx-installer /staging/usr/bin/zmproxyconfgen /usr/bin/zmproxyconfgen
+ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile-sidecar
+++ b/Dockerfile-sidecar
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM registry.dev.zextras.com/dev/carbonio-sidecar:devel
 
 # Service registration
@@ -8,8 +9,7 @@ COPY proxy/service-protocol-proxy.json /etc/carbonio/proxy/service-discover/serv
 COPY proxy/policies-proxy.json /etc/carbonio/proxy/service-discover/policies.json
 
 # Setup script
-COPY proxy/carbonio-proxy.sh /usr/local/bin/carbonio-proxy
-RUN chmod +x /usr/local/bin/carbonio-proxy
+COPY --chmod=755 proxy/carbonio-proxy.sh /usr/local/bin/carbonio-proxy
 
 ENV SERVICE_NAME=carbonio-proxy
 ENV SETUP_SCRIPT="carbonio-proxy setup"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,6 @@ defaultPipeline {
         ]) {
             stage('Build') {
                 sh 'mvn -DskipTests=true clean install'
-                stash includes: 'target/proxyconfgen.jar', name: 'staging'
             }
 
             stage('Tests') {
@@ -39,8 +38,7 @@ defaultPipeline {
         parallel(
                 'Packages': {
                     stage('Build deb/rpm') {
-                        echo 'Building deb/rpm packages'
-                        buildStage(buildFlags: ' -ds ')
+                        buildStage(buildFlags: ' -ds ', useDefaultExcludes: false)
                     }
                     stage('Publish packages') {
                         withJfrog {
@@ -68,11 +66,13 @@ EOF
                                         dockerfile: 'Dockerfile',
                                         imageName : 'carbonio-proxy',
                                         ocLabels  : [title: 'Carbonio Proxy'],
+                                        platforms : ['linux/amd64', 'linux/arm64'] as Set,
                                 ])
                                 dockerStage([
                                         dockerfile: 'Dockerfile-sidecar',
                                         imageName : 'carbonio-proxy-sidecar',
                                         ocLabels  : [title: 'Carbonio Proxy Sidecar'],
+                                        platforms : ['linux/amd64', 'linux/arm64'] as Set,
                                 ])
                             } finally {
                                 sh 'rm -f auth.conf'

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 build:
 	docker run --rm -it \
+		--entrypoint=bash \
 		--workdir /project \
 		-v $(shell pwd):/project \
-		docker.io/m0rf30/yap-ubuntu-focal:1.11 \
-		build ubuntu-focal package -sdc
+		docker.io/m0rf30/yap-ubuntu-jammy:2.0.1 \
+		-c "sudo yap build ubuntu-jammy proxy -sdc"
 
 sys-install: host-check
 	./install-packages.sh ${HOST}

--- a/build_package.sh
+++ b/build_package.sh
@@ -8,9 +8,11 @@ OS=${1:-"ubuntu-jammy"}
 
 echo "Building for OS: $OS"
 
+mkdir -p "$(pwd)/artifacts/${OS}"
+
 docker run -it --rm \
-    --entrypoint=yap \
-    -v "$(pwd)/artifacts/${OS}":/artifacts \
-    -v "$(pwd)":/tmp/build \
-    "docker.io/m0rf30/yap-${OS}:1.8" \
-    build "${OS}" /tmp/build
+  --entrypoint=bash \
+  -v "$(pwd)/artifacts/${OS}":/artifacts \
+  -v "$(pwd)":/tmp/build \
+  "docker.io/m0rf30/yap-${OS}:2.0.1" \
+  -c 'sudo yap build "${OS}" /tmp/build -sdc'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# /run is tmpfs — ensure required dirs exist at container start
+mkdir -p /run/carbonio
+
 sed -i -e "s#LDAP_URL#${LDAP_URL}#g" /localconfig/localconfig.xml
 sed -i -e "s/LDAP_ROOT_PASSWORD/${LDAP_ROOT_PASSWORD}/g" /localconfig/localconfig.xml
 sed -i -e "s/LDAP_ADMIN_PASSWORD/${LDAP_ADMIN_PASSWORD}/g" /localconfig/localconfig.xml

--- a/proxy/PKGBUILD
+++ b/proxy/PKGBUILD
@@ -71,46 +71,43 @@ sha256sums=(
 )
 
 _package() {
-  cd "$(dirname "$(find / -name "yap.json" -print -quit)")"
-
-  install -D target/proxyconfgen.jar \
+  install -D "${repodir}/target/proxyconfgen.jar" \
     "${pkgdir}/opt/zextras/lib/jars/proxyconfgen.jar"
 
-  cd "${srcdir}/.."
   # start install proxy service registration files for consul
-  install -Dm755 "${pkgname}.sh" \
+  install -Dm755 "${srcdir}/${pkgname}.sh" \
     "${pkgdir}/usr/bin/${pkgname}"
 
-  install -Dm644 "policies-proxy.json" \
+  install -Dm644 "${srcdir}/policies-proxy.json" \
     "${pkgdir}/etc/carbonio/proxy/service-discover/policies.json"
 
-  install -Dm644 "${pkgname}.hcl" \
+  install -Dm644 "${srcdir}/${pkgname}.hcl" \
     "${pkgdir}/etc/zextras/service-discover/${pkgname}.hcl"
 
-  install -Dm644 "service-protocol-proxy.json" \
+  install -Dm644 "${srcdir}/service-protocol-proxy.json" \
     "${pkgdir}/etc/carbonio/proxy/service-discover/service-protocol.json"
 
-  install -Dm755 "311-${pkgname}-setup.sh" \
+  install -Dm755 "${srcdir}/311-${pkgname}-setup.sh" \
     "${pkgdir}/etc/zextras/pending-setups.d/311-${pkgname}-setup.sh"
   # end install proxy service registration files for consul
 
   # start install clamav-signature-provider service registration files for consul
-  install -Dm755 "carbonio-clamav-signature-provider" \
+  install -Dm755 "${srcdir}/carbonio-clamav-signature-provider" \
     "${pkgdir}/usr/bin/carbonio-clamav-signature-provider"
 
-  install -Dm644 "policies-clamav-signature-provider.json" \
+  install -Dm644 "${srcdir}/policies-clamav-signature-provider.json" \
     "${pkgdir}/etc/carbonio/clamav-signature-provider/service-discover/policies.json"
 
-  install -Dm644 "carbonio-clamav-signature-provider.hcl" \
+  install -Dm644 "${srcdir}/carbonio-clamav-signature-provider.hcl" \
     "${pkgdir}/etc/zextras/service-discover/carbonio-clamav-signature-provider.hcl"
 
-  install -Dm644 "intentions-clamav-signature-provider.json" \
+  install -Dm644 "${srcdir}/intentions-clamav-signature-provider.json" \
     "${pkgdir}/etc/carbonio/clamav-signature-provider/service-discover/intentions.json"
 
-  install -Dm644 "service-protocol-clamav-signature-provider.json" \
+  install -Dm644 "${srcdir}/service-protocol-clamav-signature-provider.json" \
     "${pkgdir}/etc/carbonio/clamav-signature-provider/service-discover/service-protocol.json"
 
-  install -Dm755 "211-carbonio-clamav-signature-provider-setup.sh" \
+  install -Dm755 "${srcdir}/211-carbonio-clamav-signature-provider-setup.sh" \
     "${pkgdir}/etc/zextras/pending-setups.d/211-carbonio-clamav-signature-provider-setup.sh"
   # end install clamav-signature-provider service registration files for consul
 
@@ -121,9 +118,9 @@ _package() {
   mkdir -p "${pkgdir}/opt/zextras/conf/nginx/extensions/"
   mkdir -p "${pkgdir}/opt/zextras/data/nginx/html/"
 
-  cp conf/nginx/templates/*.template \
+  cp "${repodir}/proxy/conf/nginx/templates/"*.template \
     "${pkgdir}/opt/zextras/conf/nginx/templates/"
-  cp conf/nginx/errors/*.html \
+  cp "${repodir}/proxy/conf/nginx/errors/"*.html \
     "${pkgdir}/opt/zextras/data/nginx/html/"
   # end install template and errors files
 
@@ -138,7 +135,7 @@ _package() {
 
 _package_systemd() {
   # systemd units and target
-  install -Dm 644 "${pkgname}.target" \
+  install -Dm644 "${srcdir}/${pkgname}.target" \
     "${pkgdir}/usr/lib/systemd/system/${pkgname}.target"
 }
 
@@ -202,18 +199,18 @@ package() {
   _package
   _package_systemd
 
-  install -Dm644 "${srcdir}/../${pkgname}-sidecar.service" \
+  install -Dm644 "${srcdir}/${pkgname}-sidecar.service" \
     "${pkgdir}/usr/lib/systemd/system/${pkgname}-sidecar.service"
-  install -Dm644 "${srcdir}/../carbonio-clamav-signature-provider-sidecar.service" \
+  install -Dm644 "${srcdir}/carbonio-clamav-signature-provider-sidecar.service" \
     "${pkgdir}/usr/lib/systemd/system/carbonio-clamav-signature-provider-sidecar.service"
 }
 
 package__rocky_8() {
   _package
 
-  install -Dm644 "${srcdir}/../${pkgname}-sidecar-legacy.service" \
+  install -Dm644 "${srcdir}/${pkgname}-sidecar-legacy.service" \
     "${pkgdir}/usr/lib/systemd/system/${pkgname}-sidecar.service"
-  install -Dm644 "${srcdir}/../carbonio-clamav-signature-provider-sidecar-legacy.service" \
+  install -Dm644 "${srcdir}/carbonio-clamav-signature-provider-sidecar-legacy.service" \
     "${pkgdir}/usr/lib/systemd/system/carbonio-clamav-signature-provider-sidecar.service"
 }
 
@@ -221,18 +218,18 @@ package__rocky_9() {
   _package
   _package_systemd
 
-  install -Dm644 "${srcdir}/../${pkgname}-sidecar.service" \
+  install -Dm644 "${srcdir}/${pkgname}-sidecar.service" \
     "${pkgdir}/usr/lib/systemd/system/${pkgname}-sidecar.service"
-  install -Dm644 "${srcdir}/../carbonio-clamav-signature-provider-sidecar.service" \
+  install -Dm644 "${srcdir}/carbonio-clamav-signature-provider-sidecar.service" \
     "${pkgdir}/usr/lib/systemd/system/carbonio-clamav-signature-provider-sidecar.service"
 }
 
 package__ubuntu_jammy() {
   _package
 
-  install -Dm644 "${srcdir}/../${pkgname}-sidecar-legacy.service" \
+  install -Dm644 "${srcdir}/${pkgname}-sidecar-legacy.service" \
     "${pkgdir}/usr/lib/systemd/system/${pkgname}-sidecar.service"
-  install -Dm644 "${srcdir}/../carbonio-clamav-signature-provider-sidecar-legacy.service" \
+  install -Dm644 "${srcdir}/carbonio-clamav-signature-provider-sidecar-legacy.service" \
     "${pkgdir}/usr/lib/systemd/system/carbonio-clamav-signature-provider-sidecar.service"
 }
 
@@ -240,9 +237,9 @@ package__ubuntu_noble() {
   _package
   _package_systemd
 
-  install -Dm644 "${srcdir}/../${pkgname}-sidecar.service" \
+  install -Dm644 "${srcdir}/${pkgname}-sidecar.service" \
     "${pkgdir}/usr/lib/systemd/system/${pkgname}-sidecar.service"
-  install -Dm644 "${srcdir}/../carbonio-clamav-signature-provider-sidecar.service" \
+  install -Dm644 "${srcdir}/carbonio-clamav-signature-provider-sidecar.service" \
     "${pkgdir}/usr/lib/systemd/system/carbonio-clamav-signature-provider-sidecar.service"
 }
 


### PR DESCRIPTION
- Jenkinsfile: add platforms linux/amd64 + linux/arm64 to both carbonio-proxy and carbonio-proxy-sidecar dockerStage calls.
- Dockerfile: 2-stage no-QEMU build
  - Stage 1 (BUILDPLATFORM): apt-get download + dpkg -x for TARGETARCH packages (carbonio-nginx + runtime libs), no postinst scripts, no service-discover/carbonio-core dep chain. Libs in /usr/local/lib. Self-signed cert and zmproxyconfgen wrapper pre-generated natively.
  - Stage 2 (TARGETPLATFORM): pure COPY + ENV, zero RUN steps. LD_LIBRARY_PATH set for runtime lib discovery.
- Dockerfile-sidecar: replace RUN chmod with COPY --chmod=755 to avoid exec format error under QEMU on arm64 builders.