### PR TITLE
chore: update maven-compiler-plugin to version 3.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.14.1</version>
+          <version>3.15.0</version>
         </plugin>
         <!-- Testing -->
         <plugin>


### PR DESCRIPTION
this is clean version of original renovate version bump PR https://github.com/zextras/carbonio-proxy/pull/210/changes

I found unwanted changes in the original renovate PR. So open manually this one. 