### PR TITLE
feat(CO-3776): Enable browser caching for fingerprinted static assets served by proxy

### DIFF
--- a/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
@@ -99,6 +99,7 @@ server
     {
         ${web.add.headers.default}
         add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
         alias /opt/zextras/admin/$1;
     }
 

--- a/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
@@ -103,6 +103,14 @@ server
         alias /opt/zextras/admin/$1;
     }
 
+    location ~ "^/static/(login/assets/[a-f0-9]{8,}\..+)$"
+    {
+        ${web.add.headers.default}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
+        alias /opt/zextras/admin/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.default}

--- a/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.default.template
@@ -95,6 +95,13 @@ server
         alias /opt/zextras/admin/iris/carbonio-admin-ui/current/;
     }
 
+    location ~ "^/static/(iris/[^/]+/[a-f0-9]{7,}/.*)$"
+    {
+        ${web.add.headers.default}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        alias /opt/zextras/admin/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.default}

--- a/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
@@ -100,6 +100,7 @@ server
     {
         ${web.add.headers.vhost}
         add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
         alias /opt/zextras/admin/$1;
     }
 

--- a/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
@@ -104,6 +104,14 @@ server
         alias /opt/zextras/admin/$1;
     }
 
+    location ~ "^/static/(login/assets/[a-f0-9]{8,}\..+)$"
+    {
+        ${web.add.headers.vhost}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
+        alias /opt/zextras/admin/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.vhost}

--- a/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.carbonio.admin.template
@@ -96,6 +96,13 @@ server
         alias /opt/zextras/admin/iris/carbonio-admin-ui/current/;
     }
 
+    location ~ "^/static/(iris/[^/]+/[a-f0-9]{7,}/.*)$"
+    {
+        ${web.add.headers.vhost}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        alias /opt/zextras/admin/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.vhost}

--- a/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
@@ -91,6 +91,7 @@ server
     {
         ${web.add.headers.default}
         add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
         alias /opt/zextras/web/$1;
     }
 

--- a/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
@@ -87,6 +87,13 @@ server
         ${web.carbonio.webui.logout.redirect.default};
     }
 
+    location ~ "^/static/(iris/[^/]+/[a-f0-9]{7,}/.*)$"
+    {
+        ${web.add.headers.default}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        alias /opt/zextras/web/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.default}

--- a/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
@@ -95,6 +95,14 @@ server
         alias /opt/zextras/web/$1;
     }
 
+    location ~ "^/static/(login/assets/[a-f0-9]{8,}\..+)$"
+    {
+        ${web.add.headers.default}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
+        alias /opt/zextras/web/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.default}

--- a/proxy/conf/nginx/templates/nginx.conf.web.http.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.template
@@ -61,6 +61,13 @@ server
         ${web.carbonio.webui.logout.redirect.vhost};
     }
 
+    location ~ "^/static/(iris/[^/]+/[a-f0-9]{7,}/.*)$"
+    {
+        ${web.add.headers.vhost}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        alias /opt/zextras/web/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.vhost}

--- a/proxy/conf/nginx/templates/nginx.conf.web.http.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.template
@@ -69,6 +69,14 @@ server
         alias /opt/zextras/web/$1;
     }
 
+    location ~ "^/static/(login/assets/[a-f0-9]{8,}\..+)$"
+    {
+        ${web.add.headers.vhost}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
+        alias /opt/zextras/web/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.vhost}

--- a/proxy/conf/nginx/templates/nginx.conf.web.http.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.template
@@ -65,6 +65,7 @@ server
     {
         ${web.add.headers.vhost}
         add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
         alias /opt/zextras/web/$1;
     }
 

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -119,6 +119,14 @@ server
         alias /opt/zextras/web/$1;
     }
 
+    location ~ "^/static/(login/assets/[a-f0-9]{8,}\..+)$"
+    {
+        ${web.add.headers.default}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
+        alias /opt/zextras/web/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.default}

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -115,6 +115,7 @@ server
     {
         ${web.add.headers.default}
         add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
         alias /opt/zextras/web/$1;
     }
 

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -111,6 +111,13 @@ server
         ${web.carbonio.webui.logout.redirect.default};
     }
 
+    location ~ "^/static/(iris/[^/]+/[a-f0-9]{7,}/.*)$"
+    {
+        ${web.add.headers.default}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        alias /opt/zextras/web/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.default}

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.template
@@ -73,6 +73,13 @@ server
         ${web.carbonio.webui.logout.redirect.vhost};
     }
 
+    location ~ "^/static/(iris/[^/]+/[a-f0-9]{7,}/.*)$"
+    {
+        ${web.add.headers.vhost}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        alias /opt/zextras/web/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.vhost}

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.template
@@ -77,6 +77,7 @@ server
     {
         ${web.add.headers.vhost}
         add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
         alias /opt/zextras/web/$1;
     }
 

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.template
@@ -81,6 +81,14 @@ server
         alias /opt/zextras/web/$1;
     }
 
+    location ~ "^/static/(login/assets/[a-f0-9]{8,}\..+)$"
+    {
+        ${web.add.headers.vhost}
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        etag off;
+        alias /opt/zextras/web/$1;
+    }
+
     location ~/static/(.*)
     {
         ${web.add.headers.vhost}


### PR DESCRIPTION
This PR introduces long-lived caching headers for fingerprinted static assets served under `/static/`, aiming to improve client-side caching efficiency for Carbonio Web UI and Admin UI content.

**Changes:**
- Added dedicated `location` blocks for `/static/iris/<app>/<hash>/...` assets with `Cache-Control: public, max-age=31536000, immutable` and `etag off`.
- Added dedicated `location` blocks for `/static/login/assets/<hash>.<ext>` assets with the same immutable caching policy.
- Applied the above consistently across HTTP/HTTPS and default/vhost templates for both Web UI and Admin UI.
