### PR TITLE
fix(deps): add explicit service-discover-base dependency

### DIFF
--- a/proxy/PKGBUILD
+++ b/proxy/PKGBUILD
@@ -20,6 +20,7 @@ depends__apt=(
   "carbonio-nginx"
   "carbonio-prometheus-nginx-exporter"
   "sqlite3"
+  "service-discover-base"
 )
 depends__yum=(
   "carbonio-certbot"
@@ -27,6 +28,7 @@ depends__yum=(
   "carbonio-nginx"
   "carbonio-prometheus-nginx-exporter"
   "sqlite"
+  "service-discover-base"
 )
 source=(
   "211-carbonio-clamav-signature-provider-setup.sh"


### PR DESCRIPTION
## Summary

Fixes CO-3711: sidecar services fail when `/usr/bin/service-discover-wrapper.sh` is missing.

## Root Cause

`service-discover-wrapper.sh` is provided by `service-discover-base`. This package was only a transitive dependency, so if it became stale or mismatched (e.g. installed from a devel repo with a NEVRA no longer available), `dnf reinstall` could not restore the missing file.

## Fix

Add `service-discover-base` as an explicit dependency so the package manager enforces it at install/upgrade time.

## References

- [CO-3711](https://zextras.atlassian.net/browse/CO-3711)

[CO-3711]: https://zextras.atlassian.net/browse/CO-3711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ