### PR TITLE
build: migrate to buildah (FQDN images + jenkins-lib-common@2.10.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # (no dep resolution, no postinst scripts, no service-discover/resolvconf).
 # Also pre-generates the self-signed cert and zmproxyconfgen wrapper so the
 # final stage needs zero RUN steps.
-FROM --platform=$BUILDPLATFORM ubuntu:jammy AS nginx-installer
+FROM --platform=$BUILDPLATFORM docker.io/library/ubuntu:jammy AS nginx-installer
 
 ARG TARGETARCH
 ARG BUILDARCH=amd64

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.8.8',
+    identifier: 'jenkins-lib-common@v2.10.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
## Buildah migration

Replacing `docker buildx` with **buildah**, which requires fully-qualified image references.

### Changes
- **Dockerfiles:** fully-qualify base images (e.g. `alpine:3` -> `docker.io/library/alpine:3`). Multi-stage aliases and already-qualified refs untouched.
- **Jenkinsfile:** bump `jenkins-lib-common` to `@2.10.0`.

> Draft - part of org-wide buildah migration.