### PR TITLE
fix(CO-3656): update NGINX location regex to allow trailing slashes

### DIFF
--- a/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
@@ -715,7 +715,7 @@ server
     ${web.ews.upstream.disable}     proxy_redirect http://$relhost/ http://$http_host/;
     ${web.ews.upstream.disable} }
 
-    location ~* /(service|principals|dav|\.well-known|home|shf|user|certauth|spnegoauth)/
+    location ~* /(service|principals|dav|\.well-known|home|shf|user|certauth|spnegoauth)($|/)
     {
         # Memcached poisoning with unauthenticated request
         if ($request_uri ~* "%0A|%0D") {

--- a/proxy/conf/nginx/templates/nginx.conf.web.http.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.template
@@ -743,7 +743,7 @@ server
     ${web.ews.upstream.disable}     proxy_redirect http://$relhost/ http://$http_host/;
     ${web.ews.upstream.disable} }
 
-    location ~* /(service|principals|dav|\.well-known|home|shf|user|certauth|spnegoauth)/
+    location ~* /(service|principals|dav|\.well-known|home|shf|user|certauth|spnegoauth)($|/)
     {
         # Memcached poisoning with unauthenticated request
         if ($request_uri ~* "%0A|%0D") {

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -739,7 +739,7 @@ server
     ${web.ews.upstream.disable}     proxy_redirect http://$relhost/ https://$http_host/;
     ${web.ews.upstream.disable} }
 
-    location ~* /(service|principals|dav|\.well-known|home|shf|user|certauth|spnegoauth)/
+    location ~* /(service|principals|dav|\.well-known|home|shf|user|certauth|spnegoauth)($|/)
     {
         # Memcached poisoning with unauthenticated request
         if ($request_uri ~* "%0A|%0D") {

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.template
@@ -755,7 +755,7 @@ server
     ${web.ews.upstream.disable}     proxy_redirect http://$relhost/ https://$http_host/;
     ${web.ews.upstream.disable} }
 
-    location ~* /(service|principals|dav|\.well-known|home|shf|user|certauth|spnegoauth)/
+    location ~* /(service|principals|dav|\.well-known|home|shf|user|certauth|spnegoauth)($|/)
     {
         # Memcached poisoning with unauthenticated request
         if ($request_uri ~* "%0A|%0D") {


### PR DESCRIPTION
Carbonio previously accepted DAV requests only on URLs ending in `/` (e.g. `https://server.name/dav/`). URLs without the trailing slash (`https://server.name/dav`) did not match
  the nginx `location` block and were rejected. Many DAV clients strip the trailing slash automatically, breaking calendar/contacts (CalDAV/CardDAV) sync for affected users.

  ## Change

  Updated the `location` regex so the path segment can be terminated by either end-of-string or a slash, making the trailing slash optional:

  ```diff
  - location ~* /(service|principals|dav|\.well-known|home|shf|user|certauth|spnegoauth)/
  + location ~* /(service|principals|dav|\.well-known|home|shf|user|certauth|spnegoauth)($|/)
  ```

Applied to **all four web templates**:

  - proxy/conf/nginx/templates/nginx.conf.web.https.template
  - proxy/conf/nginx/templates/nginx.conf.web.https.default.template
  - proxy/conf/nginx/templates/nginx.conf.web.http.template
  - proxy/conf/nginx/templates/nginx.conf.web.http.default.template

  The Jira ticket names only the two `https` templates and suggests `(\/*)`. This PR intentionally deviates:
- All four templates are updated so trailing-slash handling is consistent across both http and https.
- `($|/)` is used instead of `(\/*)`. Since nginx regex location matches unanchored, `(\/*)` (zero-or-more slashes) drops the segment boundary and over-matches sibling paths such as `/davfoo`, `/services`, and `/user123`, routing them through the `auth/proxy` block. `($|/)` matches exactly `/dav` and `/dav/...`, preserving the original routing semantics for every other path.