### PR TITLE
fix(CO-3679): scope .well-known ACME location to acme-challenge only

### DIFF
--- a/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.default.template
@@ -110,11 +110,12 @@ server
         alias /opt/zextras/web/$1;
     }
 
-    location ~/.well-known/(.*)
+    # Serve ACME challenges from disk; other well-known URIs proxy to mailbox.
+    location ~ /\.well-known/acme-challenge/(.*)
     {
         ${web.add.headers.default}
         add_header Cache-Control "no-cache,must-revalidate,no-transform,max-age=604800";
-        alias /opt/zextras/.well-known/$1;
+        alias /opt/zextras/.well-known/acme-challenge/$1;
     }
 
     location /meeting

--- a/proxy/conf/nginx/templates/nginx.conf.web.http.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.http.template
@@ -84,11 +84,12 @@ server
         alias /opt/zextras/web/$1;
     }
 
-    location ~/.well-known/(.*)
+    # Serve ACME challenges from disk; other well-known URIs proxy to mailbox.
+    location ~ /\.well-known/acme-challenge/(.*)
     {
         ${web.add.headers.vhost}
         add_header Cache-Control "no-cache,must-revalidate,no-transform,max-age=604800";
-        alias /opt/zextras/.well-known/$1;
+        alias /opt/zextras/.well-known/acme-challenge/$1;
     }
 
     location /meeting

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.default.template
@@ -134,11 +134,12 @@ server
         alias /opt/zextras/web/$1;
     }
 
-    location ~/.well-known/(.*)
+    # Serve ACME challenges from disk; other well-known URIs proxy to mailbox.
+    location ~ /\.well-known/acme-challenge/(.*)
     {
         ${web.add.headers.default}
         add_header Cache-Control "no-cache,must-revalidate,no-transform,max-age=604800";
-        alias /opt/zextras/.well-known/$1;
+        alias /opt/zextras/.well-known/acme-challenge/$1;
     }
 
     location /meeting

--- a/proxy/conf/nginx/templates/nginx.conf.web.https.template
+++ b/proxy/conf/nginx/templates/nginx.conf.web.https.template
@@ -96,11 +96,12 @@ server
         alias /opt/zextras/web/$1;
     }
 
-    location ~/.well-known/(.*)
+    # Serve ACME challenges from disk; other well-known URIs proxy to mailbox.
+    location ~ /\.well-known/acme-challenge/(.*)
     {
         ${web.add.headers.vhost}
         add_header Cache-Control "no-cache,must-revalidate,no-transform,max-age=604800";
-        alias /opt/zextras/.well-known/$1;
+        alias /opt/zextras/.well-known/acme-challenge/$1;
     }
 
     location /meeting


### PR DESCRIPTION
### Problem

The `.well-known` location added for Let's Encrypt/Certbot served the **entire**
`/.well-known/*` namespace from disk:

```nginx
location ~ /\.well-known/(.*) {
    alias /opt/zextras/.well-known/$1;
}
```

Since Nginx stops at the first matching regex location, this configuration
shadowed `/.well-known/caldav` and `/.well-known/carddav`, which must be
forwarded to the mailbox backend (`DavWellKnownServlet`, mapped to
`/.well-known/*`) for RFC 6764 CalDAV/CardDAV auto-discovery.

As a result, these requests were served from the filesystem instead of being
proxied to the mailbox backend, breaking client auto-configuration.

### Fix

Restrict the disk-serving location to the ACME challenge path only. All other
`/.well-known/*` requests will then fall through to the existing proxy location
and reach the mailbox backend as intended.

```nginx
location ~ /\.well-known/acme-challenge/(.*) {
    alias /opt/zextras/.well-known/acme-challenge/$1;
}
```

This change ensures that:

- ACME challenge requests continue to be served from the same on-disk location, so the Certbot webroot flow remains unchanged.
- `/.well-known/caldav`, `/.well-known/carddav`, and any other `/.well-known/*` URIs are once again proxied to the mailbox backend.

The fix has been applied to all four web templates (`http`, `https`, and their `.default` variants).

### Testing

[x] `curl -I https://<host>/.well-known/caldav` returns a `301` redirect to the DAV endpoint.
[x] ACME challenge files continue to be served correctly from the filesystem.