### PR TITLE
chore: point semantic-release at main branch

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -8,7 +8,7 @@
  * @type {import('semantic-release').GlobalConfig}
  */
 export default {
-  branches: ['devel'],
+  branches: ['main'],
   tagFormat: "${version}",
   plugins: [
     [


### PR DESCRIPTION
Part of the GitHub default-branch rename (devel -> main, old main -> legacy-main), Wave 1. This repo has an existing `main` branch -- per the migration plan it gets renamed to `legacy-main`, then `devel` becomes the new `main`.

`release.config.mjs` had `branches: ['devel']` hardcoded. Updated to `branches: ['main']` so semantic-release keeps releasing after the branch rename.

Note: this repo also has, NOT included in this PR (semantic-release config only), flagging separately:
- `Dockerfile:38` -- apt repo URL `repo.area51-zextras.com/devel/ubuntu`
- `Dockerfile:77` -- `FROM ...carbonio-mailbox:devel`
- `Dockerfile-sidecar:2` -- `FROM ...carbonio-sidecar:devel`

No open PRs currently target `main` in this repo, so nothing gets silently retargeted to `legacy-main`.

Merge at/after the rename window to avoid a release gap.